### PR TITLE
Adding logic to use spellfile directory if it's set

### DIFF
--- a/plugin/spellsync.vim
+++ b/plugin/spellsync.vim
@@ -1,6 +1,6 @@
 " If spellfile exists use that directory
 if (len(&spellfile) > 0)
-	let s:dirs = split(fnamemodify(&spellfile,":h"), '\n')
+	let s:dirs = [fnamemodify(&spellfile,":h")]
 " Otherwise get available built-in spell directories
 else
 	let s:dirs = split(globpath(&rtp, 'spell'), '\n')

--- a/plugin/spellsync.vim
+++ b/plugin/spellsync.vim
@@ -1,5 +1,10 @@
-" Get available spell directories
-let s:dirs = split(globpath(&rtp, 'spell'), '\n')
+" If spellfile exists use that directory
+if (len(&spellfile) > 0)
+	let s:dirs = split(fnamemodify(&spellfile,":h"), '\n')
+" Otherwise get available built-in spell directories
+else
+	let s:dirs = split(globpath(&rtp, 'spell'), '\n')
+endif
 
 " Search each spell directory for word lists
 for s:dir in s:dirs


### PR DESCRIPTION
Added some logic to first try to use the directory containing the spellfile if spellfile is set, before using the built-in spell directories. I needed this for my own use case and it's working well. 